### PR TITLE
feat(twitter): add follow users command

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -1,6 +1,7 @@
 """CLI commands for the Nate social media assistant application."""
 
 from os import getenv
+from pathlib import Path
 
 import click
 from dotenv import load_dotenv
@@ -120,3 +121,64 @@ def twitter_post(model, dry_run, thread, sample):
             click.echo("Tweet posted successfully!")
         else:
             click.echo("Dry run - tweet not posted")
+
+
+@twitter.command(name="follow")
+@click.option("--users", "-u", help="Comma-separated list of usernames to follow")
+@click.option(
+    "--file",
+    "-f",
+    type=click.Path(exists=True),
+    help="File containing usernames (one per line)",
+)
+def follow_users(users, file):
+    """Follow multiple users specified directly or from a file."""
+    if not users and not file:
+        click.echo("Error: Please provide either --users or --file option")
+        return
+
+    usernames = set()
+
+    if users:
+        # Add usernames from command line
+        usernames.update(username.strip() for username in users.split(","))
+
+    if file:
+        # Add usernames from file
+        file_path = Path(file)
+        try:
+            with file_path.open("r", encoding="utf-8") as f:
+                file_usernames = [line.strip() for line in f if line.strip()]
+                usernames.update(file_usernames)
+        except Exception as e:
+            click.echo(f"Error reading file: {e}")
+            return
+
+    if not usernames:
+        click.echo("No valid usernames provided")
+        return
+
+    client = TwitterClient(
+        api_key=getenv("TWITTER_API_KEY"),
+        api_secret=getenv("TWITTER_API_SECRET"),
+        access_token=getenv("TWITTER_ACCESS_TOKEN"),
+        access_token_secret=getenv("TWITTER_ACCESS_TOKEN_SECRET"),
+    )
+
+    success_count = 0
+    for username in usernames:
+        try:
+            # Remove '@' if present
+            if username.startswith("@"):
+                username = username[1:]
+
+            # Assuming there's an existing follow_user function in the API client
+            if client.follow_user(username):
+                click.echo(f"Successfully followed @{username}")
+                success_count += 1
+            else:
+                click.echo(f"Failed to follow @{username}")
+        except Exception as e:
+            click.echo(f"Failed to follow @{username}: {e}")
+
+    click.echo(f"\nFollowed {success_count} out of {len(usernames)} users")

--- a/app/twitter/TwitterClient.py
+++ b/app/twitter/TwitterClient.py
@@ -61,6 +61,29 @@ class TwitterClient:
             )
             previous_id = response.data["id"]
 
+    def follow_user(self, username) -> bool:
+        """
+        Follow a user given their username
+
+        Args:
+            username (str): The username of the account to follow
+
+        Returns:
+            bool: True if successfully followed, False otherwise
+        """
+        try:
+            # First get the user ID from username
+            user = self.client.get_user(username=username, user_auth=True)
+            if not user.data:
+                return False
+
+            # Follow the user using their ID
+            self.client.follow_user(user.data.id)
+            return True
+        except Exception as e:
+            print(f"Error following user: {e}")
+            return False
+
     def get_sample_timeline(self):
         """Return sample timeline data for testing"""
 


### PR DESCRIPTION
Add new CLI command to follow multiple Twitter users. Users can be specified directly via command line arguments or loaded from a file. The command supports both formats and handles errors gracefully.